### PR TITLE
Convert color string to decimal number to fix error

### DIFF
--- a/data/hotebot.json
+++ b/data/hotebot.json
@@ -57,7 +57,7 @@
     "testBook": {
         "title": "This is the Title of a Test Book",
         "quotes": "testQuotes",
-        "color": "0x0097A7"
+        "color": 38823
     },
     "testQuotes": [
         {
@@ -72,32 +72,32 @@
     "fire": {
         "title": "Those Who Hold the Fire",
         "quotes": "firequotes",
-        "color": "0x0097A7"
+        "color": 38823
     },
     "portrait": {
         "title": "Portrait of a Wide Seas Islander",
         "quotes": "portraitquotes",
-        "color": "0x0097A7"
+        "color": 38823
     },
     "pettytreasons": {
         "title": "Petty Treasons",
         "quotes": "pettytreasonsquotes",
-        "color": "0x0097A7"
+        "color": 38823
     },
     "hote": {
         "title": "The Hands of the Emperor",
         "quotes": "hotequotes",
-        "color": "0x0097A7"
+        "color": 38823
     },
     "atfots": {
         "title": "At the Feet of the Sun",
         "quotes": "atfotsquotes",
-        "color": "0x0097A7"
+        "color": 38823
     },
     "rofa": {
         "title": "The Return of Fitzroy Angursell",
         "quotes": "rofaquotes",
-        "color": "0xB30000"
+        "color": 11730944
     },
     "atfotsquotes": [
         {


### PR DESCRIPTION
For some reason I don't currently understand the host started throwing "Can't convert color to number" errors at me. Putting the colors in as decimal integers instead of hex strings fixes it. This is sort of bogus, but it gets the job done for now.