### PR TITLE
Reduce duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ config.json
 package-lock.json
 package.json
 
+arrays-*
+
 node_modules/

--- a/data/redCompanyData.json
+++ b/data/redCompanyData.json
@@ -1078,6 +1078,71 @@
             "quote": "“Have you ever been interested in someone else?”\nPali did scoff at that. “Of course not.”\n“He was different, then.”\nPali looked back at her friend, whose expression was thoughtful in the dim light cast by the fairy-lights.\n“I suppose so,” she said carelessly. “He always was, wasn’t he?”",
             "chapter": "Chapter 7",
             "percentage": 19
+        },
+        {
+            "quote": "“Oh, my cousin Kip would have liked you,” Basil said, admiration sliding into his expression.",
+            "chapter": "Chapter 8",
+            "percentage": 22
+        },
+        {
+            "quote": "The idea, the very sound of the *words*, of ‘going to sit at the feet of the Sun’, was epic poetry in her heart.",
+            "chapter": "Chapter 8",
+            "percentage": 23
+        },
+        {
+            "quote": "I looked around this room, which was full of people, all *sorts* of people, and I felt as if I had stepped right into the *Lays*, and so I knew.”\nPali had stepped into legends once or twice, and she did know.",
+            "chapter": "Chapter 8",
+            "percentage": 23
+        },
+        {
+            "quote": "I doubt he ever initiated a courtship in his life, but the first time he saw a portrait of the Emperor Artorin he actually said ‘our fates are entwined.’",
+            "chapter": "Chapter 8",
+            "percentage": 23
+        },
+        {
+            "quote": "Pali registered a certain kinship to this Kip, who did not have much interest in sex and who understood the call of Fate.",
+            "chapter": "Chapter 8",
+            "percentage": 23
+        },
+        {
+            "quote": "Pali could not help but contrast them with Professor Vane, who would almost certainly have been as enthusiastic about Pali’s home culture as Jullanar was about Basil’s. But Pali was not Jullanar, and had never known how to step out of her own reserve.",
+            "chapter": "Chapter 9",
+            "percentage": 23
+        },
+        {
+            "quote": "It was a sad thought that she might have had so much *more*, had she ever crossed the mountains into South Fiellan.",
+            "chapter": "Chapter 9",
+            "percentage": 23
+        },
+        {
+            "quote": "“You’ll have to go back to Stoneybridge, I expect—unless of course you wish to make a grand and mysterious disappearance.”\n“It’s tempting, but I would like my own horse.”",
+            "chapter": "Chapter 9",
+            "percentage": 24
+        },
+        {
+            "quote": "Pali very carefully reminded herself that she was Pali Avramapul of the Red Company, and she was not to be awestruck so easily. No doubt she was feeling slightly under the weather from a cold she’d picked up on the stagecoach.",
+            "chapter": "Chapter 9",
+            "percentage": 24
+        },
+        {
+            "quote": "*Someone* in this government cared deeply for the Archives, and funded them accordingly.",
+            "chapter": "Chapter 9",
+            "percentage": 25
+        },
+        {
+            "quote": "Back in Astandalan days people had always spoken almost familiarly of ‘Emperor Artorin’, but that custom had been replaced by his titles and especially that reverent *Lord* Emperor.",
+            "chapter": "Chapter 9",
+            "percentage": 25
+        },
+        {
+            "quote": "The Lord Chancellor, who was himself from some remote hinterland region, and who had worked hard to ensure the government was representative of the people it served.\nPali knew that very few government officials had ever even had that thought, let alone considered it good and deliberately worked to bring it into practice.",
+            "chapter": "Chapter 9",
+            "percentage": 25
+        },
+        {
+            "quote": "The greatest difference that not one person, from the page to the Chief Librarian to the Undersecretary in Chief of the Offices of the Lords of State, had shown any inclination to being bribed.",
+            "chapter": "Chapter 9",
+            "percentage": 26
         }
     ]
 }

--- a/data/server-config-1071247508732395550.json
+++ b/data/server-config-1071247508732395550.json
@@ -36,6 +36,7 @@
     },
     "scheduledQuotes": [
         {
+            "id": "9WorldsSchedule",
             "description": "quotes even hours in nine-worlds",
             "time": "0 0 0/2 * * *",
             "timezone": "America/Los_Angeles",
@@ -44,6 +45,7 @@
             ]
         },
         {
+            "id": "discussionSchedule",
             "description": "quotes odd hours in discussion channels",
             "time": "0 0 1/2 * * *",
             "timezone": "America/Los_Angeles",
@@ -57,6 +59,7 @@
     ],
     "scheduledFics": [
         {
+            "id": "ficSchedule",
             "description": "fanfic every four hours",
             "time": "0 0 0/4 * * *",
             "timezone": "America/Los_Angeles",

--- a/data/server-config-849347713547501588.json
+++ b/data/server-config-849347713547501588.json
@@ -41,6 +41,7 @@
     },
     "scheduledQuotes": [
         {
+            "id": "9WorldsSchedule",
             "description": "quotes at 9 am in nine-worlds-with-victoria",
             "time": "0 0 09 * * *",
             "timezone": "America/Los_Angeles",
@@ -49,19 +50,21 @@
             ]
         },
         {
+            "id": "discussionSchedule",
             "description": "quotes at 9 pm in discussion channels",
             "time": "0 0 21 * * *",
             "timezone": "America/Los_Angeles",
             "channels": [
+                "1004576660483477587",
                 "849348165006393364",
                 "850240485946818610",
-                "850250431782453258",
-                "1004576660483477587"
+                "850250431782453258"
             ]
         }
     ],
     "scheduledFics": [
         {
+            "id": "ficSchedule",
             "description": "fanfic at 3pm",
             "time": "0 0 15 * * *",
             "timezone": "America/Los_Angeles",

--- a/error.js
+++ b/error.js
@@ -19,7 +19,7 @@ module.exports = {
                 {
                     if (action == "quote") {
                         channelSupported =
-                            (channelConfig.quoteSourceFile != undefined) &&
+                            (channelConfig.rootSourceFile != undefined) &&
                             (channelConfig.quoteRoot != undefined);
                     }
                     else if (action == "fic") {
@@ -43,7 +43,7 @@ module.exports = {
             let supportedChannels = "";
             channels.forEach(channel => {
                 if ((action == "quote") &&
-                    (channel.quoteSourceFile != undefined) &&
+                    (channel.rootSourceFile != undefined) &&
                     (channel.quoteRoot != undefined)) {
                     supportedChannels += "\t# " + channel.description + "\n";
                     console.log("Found Supported channel: " + channel.description);

--- a/ficLinkGenerator.js
+++ b/ficLinkGenerator.js
@@ -2,6 +2,7 @@ const path = require('node:path');
 const AO3 = require('ao3');
 const { EmbedBuilder } = require('discord.js');
 const { accessSync } = require('node:fs');
+const { randomSelection } = require('./randomSelection.js');
 
 module.exports = {
     generateFicLink: async (guildId, channelId) => {
@@ -27,23 +28,22 @@ module.exports = {
                     console.log("Total results: " + search.total_results);
                     console.log("Total pages: " + search.pages);
 
-                    // Pick a random page to get a fic from (1 indexed)
-                    let randomPage = Math.ceil(Math.random() * search.pages)
-                    console.log("Random page: " + randomPage);
+                    // Reverse the index returned from randomSelection, because new fics will be added at the beginning (index 0)
+                    let ficIndex = (search.total_results - randomSelection(guildId, "fic", search.total_results));
 
+                    // Figure out what page that fic is on (1 indexed)
+                    let ficPage = Math.floor(ficIndex / 20) + 1;
+                    console.log("Page: " + ficPage);
 
                     // Do another search to get the fics on that page
                     let pageSearch = new AO3.Search(undefined, undefined, undefined, undefined, undefined, undefined,
                         fandom, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
-                        randomPage);
+                        ficPage);
 
                     await pageSearch.update();
 
-
-                    console.log("++++++++++++++++++++++++++++");
-                    console.log(pageSearch.results.length);
-
-                    let randomWork = pageSearch.results[Math.floor(Math.random() * pageSearch.results.length)];
+                    let indexOnPage = ficIndex - (ficPage - 1) * 20;
+                    let randomWork = pageSearch.results[indexOnPage];
                     console.log(randomWork.title);
 
                     let authors = "";

--- a/quoteGenerator.js
+++ b/quoteGenerator.js
@@ -1,5 +1,6 @@
 const path = require('node:path');
 const { EmbedBuilder } = require('discord.js');
+const { randomSelection } = require('./randomSelection.js');
 
 module.exports = {
     generateQuote: (guildId, channelId) => {
@@ -24,8 +25,9 @@ module.exports = {
                 let bookQuoteFile = require(path.join(__dirname, "data/" + bookConfig.quoteSourceFile));
 
                 let quoteArray = bookQuoteFile[book + "quotes"];
+                let quoteIndex = randomSelection(guildId, book, quoteArray.length);
 
-                let quoteObject = quoteArray[Math.floor(Math.random() * quoteArray.length)];
+                let quoteObject = quoteArray[quoteIndex];
                 let quote = quoteObject.quote;
                 console.log("Quote:" + quote);
 

--- a/randomSelection.js
+++ b/randomSelection.js
@@ -1,0 +1,49 @@
+var fs = require("fs");
+
+module.exports = {
+    randomSelection: (guildId, arrayId, max) => {
+
+        console.log("Random Selection!")
+        let serverArrayFileName = "./arrays-" + guildId + ".json";
+
+        let serverArrays = {};
+        try {
+            serverArrays = require(serverArrayFileName);
+            console.log("Loaded serverArrays from file");
+        }
+        catch { console.log("Failed to load serverArrays from file"); }
+
+        // Create a new array if:
+        // (a) we don't have one
+        // (b) the one we have is empty
+        // (c) the max being passed is less than the one we used to generate the current array
+        if ((serverArrays[arrayId] == null) ||
+            (serverArrays[arrayId].length == 0) ||
+            (max < serverArrays[arrayId + "Max"])) {
+
+            console.log("Making a new Array!")
+            serverArrays[arrayId] = new Array(max).fill().map((a, i) => a = i).sort(() => Math.random() - 0.5);
+            serverArrays[arrayId + "Max"] = max;
+            console.log(serverArrays);
+        }
+        // Expand the current array if the max we're being passed is greater than the one we used to 
+        // generate the current array
+        else if (max > serverArrays[arrayId + "Max"]) {
+            let oldMax = serverArrays[arrayId + "Max"];
+            let newItemsNeeded = max - oldMax;
+
+            console.log("Expanding Array!")
+
+            let newItems = new Array(newItemsNeeded).fill().map((a, i) => a = i + oldMax);
+            serverArrays[arrayId] = [].concat(serverArrays[arrayId], newItems).sort(() => Math.random() - 0.5);
+            serverArrays[arrayId + "Max"] = max;
+            console.log(serverArrays);
+        }
+
+        // Pop an index off the random array
+        let value = serverArrays[arrayId].pop();
+        console.log("Returning index " + value);
+        fs.writeFileSync(serverArrayFileName, JSON.stringify(serverArrays), () => { });
+        return value;
+    }
+}

--- a/twitterconvert.js
+++ b/twitterconvert.js
@@ -25,7 +25,6 @@ rootFile[rootName].forEach(book => {
     // Add it to the twitter result surrounded by #'s. This is to support tracery as used by Cheap Bots Done Quick
     twitterResult[book] = ["#" + book + "quotes#\n\n" + bookItem.title];
 
-
     // If we haven't come across this book before, create the quote array for it.
     if (twitterResult[book + "quotes"] == null) {
         twitterResult[book + "quotes"] = [];


### PR DESCRIPTION
Fixes #18 

Reduces duplication of fics and quotes by generating a array with a persistent random order and pulling from that array until all indexes have been used. Additional changes include:

- More Pali quotes
- Fix bug in error generation that wasn't properly detecting supported channels
- Fix bug in delay code that caused messages to fail to send if they had been delayed
- Persist current index of schedules that rotate through channels, so we don't lose our place every time the bot restarts.